### PR TITLE
Delete Post

### DIFF
--- a/components/Posts/index.js
+++ b/components/Posts/index.js
@@ -38,7 +38,12 @@ const parseLinks = text => (
     : parseMentions(text)
   );
 
-export const Posts = ({ posts, profile }) => {
+export const Posts = ({
+  posts,
+  profile,
+  user,
+  onDeletePost = () => null
+}) => {
   const Profile = () => (
     <>
       <div className={styles.profile}>
@@ -47,6 +52,8 @@ export const Posts = ({ posts, profile }) => {
       </div>
     </>
   );
+
+  const isProfileUser = user && user.username === profile;
 
   return (
     <div>
@@ -60,7 +67,7 @@ export const Posts = ({ posts, profile }) => {
       </p>
       {profile && <Profile />}
       {
-        posts.slice(0, PAGE_LIMIT).map(({ author, text, date }) => {
+        posts.slice(0, PAGE_LIMIT).map(({ id, author, text, date }) => {
           const localDateTime = (
             new Date(`${date} UTC`).toLocaleString()
           );
@@ -69,7 +76,10 @@ export const Posts = ({ posts, profile }) => {
             <div key={text} className={styles.card}>
               <a href={`/${author}`}>{`@${author}`}</a>
               <p dangerouslySetInnerHTML={{ __html: parseLinks(text) }} />
-              <a href={`/${author}`}>{localDateTime}</a>
+              <div className={styles.info}>
+                <a href={`/${author}`}>{localDateTime}</a>
+                {isProfileUser && <button onClick={onDeletePost(id)}>Delete</button>}
+              </div>
             </div>
           );
         })

--- a/pages/[username].js
+++ b/pages/[username].js
@@ -68,6 +68,28 @@ export default function UserProfile ({
     }
   };
 
+  const onClickDeletePost = postId => async () => {
+    if (!user?.token) return;
+
+    const response = await fetch('/api/post/delete', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        token: user.token,
+        postId
+      })
+    });
+
+    if (response?.ok) {
+      const { message } = await response.json();
+
+      showNotification(message);
+    }
+  };
+
   const onLoad = () => {
     const { username } = query;
 
@@ -104,7 +126,7 @@ export default function UserProfile ({
         localStorage.getItem('user') || '{}'
       );
 
-      if (cachedUser) {
+      if (cachedUser?.address) {
         setIsFetching(true);
 
         const response = await fetch('/api/auth', {
@@ -164,7 +186,12 @@ export default function UserProfile ({
         {user && <PostButton disabled={isFetching} onClick={onClickPostButton} />}
         <div className={styles.grid}>
           <Navigation tabs={tabs} />
-          <Posts posts={posts} profile={profile} />
+          <Posts
+            posts={posts}
+            profile={profile}
+            user={user}
+            onDeletePost={onClickDeletePost}
+          />
           {!user && <Auth
             onClickSignUp={onClickRegisterButton}
             onClickSignIn={onClickLoginButton}
@@ -173,7 +200,9 @@ export default function UserProfile ({
         </div>
       </main>
       <footer className={styles.footer}>
-        <a href="https://github.com/bennyschmidt/reverse" target="_blank" rel="noreferrer">Fork on GitHub</a>
+        <a href="https://github.com/bennyschmidt/reverse" target="_blank" rel="noreferrer">
+          Fork on GitHub
+        </a>
       </footer>
     </>
   );

--- a/pages/api/_blockchain.js
+++ b/pages/api/_blockchain.js
@@ -1,4 +1,5 @@
 import { request } from './_utils';
+import { getCollection } from './_mongo';
 
 const {
   DEREVA_API_KEY,
@@ -93,12 +94,25 @@ const getComments = async () => {
       } = JSON.parse(body);
 
       comments.push({
+        id: transaction.hash,
         author,
         text,
         date
       });
     })
   );
+
+  const collection = await getCollection('deleted');
+  const deletedPosts = await collection.find().toArray();
+
+  for (const deleted of deletedPosts) {
+    comments.splice(
+      comments.indexOf(
+        comments.find(({ id }) => id === deleted.postId)
+      ),
+      1
+    );
+  }
 
   return {
     transactions: comments.slice(-LIMIT)

--- a/pages/api/post/delete/index.js
+++ b/pages/api/post/delete/index.js
@@ -1,0 +1,43 @@
+import { getCollection } from '../../_mongo';
+import { getSession } from '../../_session';
+import { getUsers } from '../../_blockchain';
+
+export default async function (req, res) {
+  const { postId, token } = req.body;
+
+  const session = await getSession(token);
+
+  const users = await getUsers();
+
+  const user = users.transactions.find(user => user.address === session.address);
+
+  if (!user?.address) {
+    return res
+      .status(401)
+      .json({
+        status: 401,
+        ok: false,
+        message: 'Unauthorized.'
+      });
+  }
+
+  const collection = await getCollection('deleted');
+
+  await collection.updateOne(
+    { postId },
+    {
+      $set: {
+        postId
+      }
+    },
+    { upsert: true }
+  );
+
+  res
+    .status(200)
+    .json({
+      status: 200,
+      ok: true,
+      message: 'Post deleted.'
+    });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -242,7 +242,9 @@ export default function Home ({
         </div>
       </main>
       <footer className={styles.footer}>
-        <a href="https://github.com/bennyschmidt/reverse" target="_blank" rel="noreferrer">Fork on GitHub</a>
+        <a href="https://github.com/bennyschmidt/reverse" target="_blank" rel="noreferrer">
+          Fork on GitHub
+        </a>
       </footer>
     </>
   );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -274,6 +274,25 @@ textarea.input {
   background: #eaeaea;
 }
 
+.info {
+  display: flex;
+  justify-content: space-between;
+}
+
+.info > button {
+  background: none;
+  color: red;
+  font-weight: 400;
+  width: auto;
+  padding: 0;
+  opacity: .5;
+  display: none;
+}
+
+.card:hover .info > button {
+  display: block;
+}
+
 @media (max-width: 974px) {
   .grid {
     width: 100%;


### PR DESCRIPTION
Users can now delete posts from their own profile when logged in (it's a hover state on the card) 

Note: The transactions and related file data still exists in DRV, so the post is still publicly retrievable. We accomplish "delete" in Reverse by pushing the `postId` (transaction hash) to a Mongo collection called `deleted` (in the same db as `sessions` and the post queue). 

In `getComments` the `postId`s that exist in the collection are omitted from the API response.

![Screenshot from 2022-12-27 13-01-05](https://user-images.githubusercontent.com/45407493/209721983-f882422b-2c24-47c2-8c32-417e5069b7fb.png)
